### PR TITLE
Wifi is not working on n7000

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -5,3 +5,5 @@ system/bin/gpsd
 system/bin/gps.cer
 system/etc/gps.xml
 system/lib/libakm.so
+system/etc/wifi/nvram_mfg.txt_semcove
+system/etc/wifi/nvram_net.txt_semcove


### PR DESCRIPTION
Withouth files system/etc/wifi/nvram_mfg.txt_semcove and system/etc/wifi/nvram_net.txt_semcove wifi is not working on n7000 (can't be turned on). Nightly builds contains these files, so wifi is working. Wifi is not working if you try to build CM for the first time.
